### PR TITLE
Make TLS optional

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,17 +11,13 @@ type conf struct {
 }
 
 func getConfig() conf {
-	var local bool
-	domainName := os.Getenv("DOMAIN")
-	if domainName == "" || domainName == "localhost" {
-		domainName = "localhost"
-		local = true
+	c := conf{}
+	c.Domain = os.Getenv("DOMAIN")
+	if c.Domain == "localhost" {
+		c.Local = true
 	}
 
-	log.Println("[INFO] using domain:", domainName)
+	log.Println("[INFO] using domain:", c.Domain)
 
-	return conf{
-		Domain: domainName,
-		Local:  local,
-	}
+	return c
 }


### PR DESCRIPTION
When deployed in an existing infrastructure, it can often be desired to handle TLS by a load balancer and/or service mesh sidecar.

This makes the `DOMAIN` parameter optional, disabling TLS when unspecified.
